### PR TITLE
fix module path.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/whyrusleeping/p2pc
+module github.com/whyrusleeping/p2pbnch
 
 go 1.13
 


### PR DESCRIPTION
To fix:

```
root@localhost:~# GO111MODULE=on go get -v -fix github.com/whyrusleeping/p2pbnch
go get: -fix flag is a no-op when using modules
go: finding github.com/whyrusleeping/p2pbnch latest
go get: github.com/whyrusleeping/p2pbnch@v0.0.0-20191003171033-b4e8228c06f3: parsing go.mod:
	module declares its path as: github.com/whyrusleeping/p2pc
	        but was required as: github.com/whyrusleeping/p2pbnch
```